### PR TITLE
Page only when web components signal ready

### DIFF
--- a/ink-doc.js
+++ b/ink-doc.js
@@ -32,11 +32,18 @@ class InkDocument extends LitElement {
 
   connectedCallback() {
     super.connectedCallback()
+
+    const customElements = document.querySelector('html-import')
+    customElements.addEventListener('wc-ready', this.pageDocument)
+  }
+
+  pageDocument() {
+    console.log('pageDocument()')
     const paged = new Previewer()
     const stylesheets = Array.from(document.styleSheets).map(css => css.href)
 
-    paged.preview(document.querySelector('ink-doc').innerHTML, stylesheets, this.shadowDocument).then((flow) => {
-      document.querySelector('ink-doc').remove()
+    const html = document.querySelector('ink-doc').innerHTML
+    paged.preview(html, stylesheets, this.shadowDocument).then((flow) => {
       this.dispatchEvent(new PagedDocument('paged-doc', flow))
     })
   }


### PR DESCRIPTION
Only paginate when child web components signal they are "ready" i.e. have rendered so that Paged.js can accurately get their size.

This assumes that Paged.js is looking at the original size of elements to correct paginate them.

It also relies on a mechanism by which web components can report that rendering has completed, which does not exist for lit-element. This would have to be patched into upstream, or a mixin developed.

This patch is hard-coded to work with <html-import>. A more general solution would need to detect all compatible child custom elements and wait for to receive readiness signal before paginating, or until some time out.